### PR TITLE
Every week is quality week!

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The following is a list of core principles [epilot](https://epilot.cloud/) engin
 - [Freedom and Responsibility](#freedom-and-responsibility)
 - [Ownership: You build it, you run it](#ownership-you-build-it-you-run-it)
 - [Show, don’t tell: Deliver working software early and frequently.](#show-dont-tell-deliver-working-software-early-and-frequently)
-- [Cult of Quality](#cult-of-quality)
+- [Every Week is Quality Week](#every-week-is-quality-week)
 - [Solutions over Problems](#solutions-over-problems)
 - [API First: We design software with APIs](#api-first-we-design-software-with-apis)
 - [Rent over build: We rent the necessary and focus on building the important](#rent-over-build-we-rent-the-necessary-and-focus-on-building-the-important)
@@ -63,7 +63,7 @@ While prototypes and proof-of-concepts can be great tools early on, we should al
 - **Move fast**: Putting feedback loops in place early on helps us make more informed decisions collaboratively and commit to deliverables that create tangible progress.
 - **Risk management**: Even with great design and careful planning, unplanned work is guaranteed to appear once you're in the process of building. So better start early. 
 
-## Cult of Quality
+## Every Week is Quality Week
 
 Our teams appear cult-like when it comes to quality. We believe the code we produce is always our best work and represents our level of professional competence. No excuses.
 


### PR DESCRIPTION
**New Engineering Principle: Every week is quality week**

What do I mean by that statement?

During quality week, we showcased that we are able to make major improvements not just to code, but generally into our product by being radically focused on quality.

All the fixes and improvements from last week made our product more polished, faster and more reliable; Exactly what our customers are asking for. We also solved a big number of real issues directly for our customers by prioritising bugs reported to us. This work is 100% aligned with our company and engineering values.

So why stop doing this now?

**What about our roadmap / features?**

Our roadmap is totally dependent on our ability to deliver features on a stable foundation.

It's our job as engineers to prevent the accumulation of bugs and technical debt in order to maintain the trust of our customers and our continued ability to deliver features. [We refuse any request to lower our quality standards for the sake of cutting corners](https://github.com/epilot-dev/engineering-principles#:~:text=We%20refuse%20any%20request%20to%20lower%20our%20quality%20standards%20for%20the%20sake%20of%20cutting%20corners.).

In our current business context, it's unfortunately clear that we are not yet at a good enough level of quality.

This means we need to carry on the critical work we started during quality week. Especially all bugs, stability and security improvements. Our target should be to hit (and surpass) our target quality baseline as soon as possible.

If doing that means postponing work on a new feature – we trust you to make that decision.

Let's make every week quality week from now on!