### PR TITLE
feat: new principle "Complete the Mission"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following is a list of core principles [epilot](https://epilot.cloud/) produ
 - [Freedom and Responsibility](#freedom-and-responsibility)
 - [Continuous Delivery](#continuous-delivery)
 - [Ownership: You build it, you run it](#ownership-you-build-it-you-run-it)
+- [Complete the Mission](#complete-the-mission)
 - [Show, don’t tell: Deliver working software early and frequently.](#show-dont-tell-deliver-working-software-early-and-frequently)
 - [Every Week is Quality Week](#every-week-is-quality-week)
 - [Solutions over Problems](#solutions-over-problems)
@@ -44,6 +45,22 @@ We organize and develop our software as small decoupled services, with named eng
 - **Reliability** Our customers expect all features to work seamlessly together at all times. Testing end-to-end with realistic use cases helps prevent most regressions.
 - **Speed** Continuous delivery with automated testing allows us to ship with confidence and deliver features our customers want, faster.
 - **Modular architecture** Keeping services small and decoupled helps keep our software easier to reason about and maintain while allowing diversity in tech choices.
+
+## Complete the Mission
+
+With Freedom and Responsibility comes trust, and it's almost certain you will end up leading a squad or initiative at some point, with individuals around you to support.
+
+As a leader, people look up to you as an example, and you look up to them. It’s your job to set them up for success and ensure they have the focus and clarity to execute.
+
+At the same time, a leader must complete the mission—delivering results while balancing the long-term health of our codebase, user experience, and sustainability. This means making trade-offs between speed, quality, technical debt, and customer value, ensuring we don’t optimize for short-term wins at the cost of long-term failure.
+
+### Why?
+
+- **Ownership**: In the end, it’s your job to set the team up for success—not just today but in the long run.
+- **Risk management**: You deeply care about the team, and sometimes you will have to make difficult decisions. Risks are necessary sometimes—but they should be taken deliberately, not recklessly.
+- **Balance**: Fast execution matters, but so does avoiding technical debt, maintaining quality, and delivering a great user experience. Completing the mission means balancing all of these.
+- **Accountability**: Risk is inherent in decision-making. When things go south, leaders don’t deflect blame—they step up and own the outcome.
+- **Transparency**: A strong leader makes the mission clear, aligns the team around priorities, and ensures urgency without chaos.
 
 ## Ownership: You build it, you run it
 

--- a/README.md
+++ b/README.md
@@ -48,19 +48,8 @@ We organize and develop our software as small decoupled services, with named eng
 
 ## Complete the Mission
 
-With Freedom and Responsibility comes trust, and it's almost certain you will end up leading a squad or initiative at some point, with individuals around you to support.
-
-As a leader, people look up to you as an example, and you look up to them. It’s your job to set them up for success and ensure they have the focus and clarity to execute.
-
-At the same time, a leader must complete the mission—delivering results while balancing the long-term health of our codebase, user experience, and sustainability. This means making trade-offs between speed, quality, technical debt, and customer value, ensuring we don’t optimize for short-term wins at the cost of long-term failure.
-
-### Why?
-
-- **Ownership**: In the end, it’s your job to set the team up for success—not just today but in the long run.
-- **Risk management**: You deeply care about the team, and sometimes you will have to make difficult decisions. Risks are necessary sometimes—but they should be taken deliberately, not recklessly.
-- **Balance**: Fast execution matters, but so does avoiding technical debt, maintaining quality, and delivering a great user experience. Completing the mission means balancing all of these.
-- **Accountability**: Risk is inherent in decision-making. When things go south, leaders don’t deflect blame—they step up and own the outcome.
-- **Transparency**: A strong leader makes the mission clear, aligns the team around priorities, and ensures urgency without chaos.
+Execution matters more than details. If you don’t deliver, nothing else counts.
+There’s no credit for style, no excuses for setbacks, and no rewards for stopping short. This principle is about relentless focus—setting a clear mission and doing whatever it takes to achieve it. Perfection isn’t the goal; results are.
 
 ## Ownership: You build it, you run it
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,19 @@ We organize and develop our software as small decoupled services, with named eng
 
 ## Complete the Mission
 
-Execution matters more than details. If you don’t deliver, nothing else counts.
-There’s no credit for style, no excuses for setbacks, and no rewards for stopping short. This principle is about relentless focus—setting a clear mission and doing whatever it takes to achieve it. Perfection isn’t the goal; results are.
+Execution matters more than the details. If you don’t deliver, nothing else counts.
+
+Ownership is key—if something is your responsibility, it gets done. There’s no credit for effort alone, no excuses for setbacks, and no rewards for stopping short. This principle is about relentless focus on the outcome—setting a clear mission and ensuring it is achieved.
+	•	We take **full responsibility** for what we own and see it through to the end.
+	•	We **solve problems, not just highlight them**—delays and obstacles don’t excuse failure.
+	•	We don’t celebrate “almost done”—**real impact comes from delivery, not effort.**
+
+When faced with challenges, we find a way forward, take responsibility, and make it happen. Delivering results is what matters, whether in engineering, operations, product, or leadership.
+
+### Why?
+- **Ownership drives impact**: If no one owns a problem, it doesn’t get solved. Taking ownership means stepping up and ensuring real progress happens.
+- **Accountability creates trust**: Teams that take responsibility—both for successes and failures—are the ones people rely on.
+- **Delivery is the only measure of execution**: Ideas, discussions, and partial work mean nothing if they don’t translate into **real results**.
 
 ## Ownership: You build it, you run it
 


### PR DESCRIPTION
A new principle about ownership:

Engineers constantly navigate trade-offs: speed vs. thoroughness, risk vs. safety, and innovation vs. stability—balancing fast execution with long-term sustainability. 

Intentional decision-making means knowing when to move fast, when to refine, and always communicating trade-offs clearly. 

Engineering is about delivering high-quality, maintainable software—unfinished work and unmanaged debt break trust with both the team and customers.

Which is why I believe the principle of Complete the Mission is extremely important. As a leader you must care for the team, but also complete the mission, your prime directive.

E.g:

- You can sacrifice your goals to put the team on a good record regarding a bad bug situation => sacrificing your own weekly goals
- And right after that Leading By Example: you still deliver your mission even if it costs you some extra effort
- There are bad weeks and more easy going ones => we shouldn't be inflexible and always expect things to be perfect

And most surely, we should not let an opportunity to give the example to our team be wasted. You should use the situation to take action and reinforce that we have an high bar and that, specially the leaders, are there to deliver when they must and complete the mission.